### PR TITLE
Send to normal Checkout screen if card errors instead of Complete Payment screen

### DIFF
--- a/classes/class.pmprogateway_square.php
+++ b/classes/class.pmprogateway_square.php
@@ -64,6 +64,8 @@ class PMProGateway_square extends PMProGateway {
 			add_filter( 'pmpro_include_billing_address_fields', array( $this, 'include_billing_address_fields' ) );
 			add_filter( 'pmpro_include_payment_information_fields', array( $this, 'include_payment_information_fields' ) );	
 
+			add_filter( 'pmpro_after_checkout_preheader', array( $this, 'clear_pmpro_review' ) );			
+
 			add_filter( 'pmpro_after_update_billing', array( $this, 'update_billing_card' ), 10, 2 );	
 
 			add_action( 'wp', array( $this, 'webhook_listener' ), 999 );
@@ -1311,6 +1313,27 @@ class PMProGateway_square extends PMProGateway {
 		// If we got here, something didn't go correctly.
 		return false;
 
+	}
+
+	/**
+	 * Clear $pmpro_review.
+	 *
+	 * Do not show the Complete Payment screen if there is an error.
+	 */
+	public static function clear_pmpro_review( $pmpro_review ) {
+		// If we don't have an order, bail.
+		if ( empty( $pmpro_review ) || ! is_a( $pmpro_review, 'MemberOrder' ) ) {
+			return;
+		}
+
+		// If this is not a Square order, bail.
+		if ( 'square' !== $pmpro_review->gateway ) {
+			return;
+		}
+
+		// Clear the global.
+		global $pmpro_review;
+		$pmpro_review = false;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-testimonials/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves issue where if payment error (like declined card) it would send user to Complete Payment screen. Now puts user back on normal checkout screen with errors.

### How to test the changes in this Pull Request:

1. Use a declined card number

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Send user to main Checkout screen when card error