### PR TITLE
Fix free checkouts failing when Square is enabled

### DIFF
--- a/assets/js/square-processing.js
+++ b/assets/js/square-processing.js
@@ -51,10 +51,7 @@ async function pmpro_square_set_payment_token( token, verificationToken ) {
 	 statusContainer.style.visibility = 'visible';
  }
 
-// Mirrors the PMPro Stripe integration: track whether billing is required for this
-// checkout. PMPro seeds this from the server and the applydiscountcode service updates it
-// when a code is applied (e.g. a code that zeroes the price sets it to false), so reading
-// it at submit time also covers the case where a discount code makes the order free.
+// Kept in sync by PMPro core and the applydiscountcode service.
 var pmpro_require_billing;
 
 var pmpro_square_card;
@@ -97,11 +94,7 @@ document.addEventListener(
 		}
 		
 		async function pmpro_square_handle_submission( event, paymentMethod ) {
-			// When billing is not required - a free level, or a discount code that zeroed the
-			// price - there is no card to tokenize. Let the form submit normally so PMPro
-			// completes the checkout through its free path. This mirrors the PMPro Stripe
-			// integration, which gates on the same global that the applydiscountcode service
-			// keeps in sync, so it stays correct even when a code is applied after page load.
+			// No payment due, so skip tokenization and let the form submit normally.
 			if ( ! pmpro_require_billing ) {
 				return;
 			}

--- a/assets/js/square-processing.js
+++ b/assets/js/square-processing.js
@@ -51,10 +51,20 @@ async function pmpro_square_set_payment_token( token, verificationToken ) {
 	 statusContainer.style.visibility = 'visible';
  }
 
+// Mirrors the PMPro Stripe integration: track whether billing is required for this
+// checkout. PMPro seeds this from the server and the applydiscountcode service updates it
+// when a code is applied (e.g. a code that zeroes the price sets it to false), so reading
+// it at submit time also covers the case where a discount code makes the order free.
+var pmpro_require_billing;
+
 var pmpro_square_card;
 document.addEventListener(
 	'DOMContentLoaded',
 	async function ( e ) {
+		if ( typeof pmpro_require_billing === 'undefined' ) {
+			pmpro_require_billing = pmpro_square_vars.pmpro_require_billing;
+		}
+
 		if ( ! window.Square ) {
 			throw new Error( 'Square.js failed to load properly' );
 		}
@@ -87,6 +97,14 @@ document.addEventListener(
 		}
 		
 		async function pmpro_square_handle_submission( event, paymentMethod ) {
+			// When billing is not required - a free level, or a discount code that zeroed the
+			// price - there is no card to tokenize. Let the form submit normally so PMPro
+			// completes the checkout through its free path. This mirrors the PMPro Stripe
+			// integration, which gates on the same global that the applydiscountcode service
+			// keeps in sync, so it stays correct even when a code is applied after page load.
+			if ( ! pmpro_require_billing ) {
+				return;
+			}
 			event.preventDefault();
 			try {
 				const pmpro_square_token      = await pmpro_square_tokenize( paymentMethod );

--- a/classes/class.pmprogateway_square.php
+++ b/classes/class.pmprogateway_square.php
@@ -545,7 +545,7 @@ class PMProGateway_square extends PMProGateway {
 	public function include_payment_information_fields() {
 		global $pmpro_requirebilling;
 		?>
-		<fieldset id="pmpro_payment_information_fields" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fieldset', 'pmpro_payment_information_fields' ) ); ?>" <?php if ( ! $pmpro_requirebilling ) { ?>style="display: none;"<?php } ?>>
+		<fieldset id="pmpro_payment_information_fields" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fieldset', 'pmpro_payment_information_fields' ) ); ?>" <?php if ( ! $pmpro_requirebilling || apply_filters( 'pmpro_hide_payment_information_fields', false ) ) { ?>style="display: none;"<?php } ?>>
 			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card' ) ); ?>">
 				<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
 					<legend class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_legend' ) ); ?>">

--- a/classes/class.pmprogateway_square.php
+++ b/classes/class.pmprogateway_square.php
@@ -501,6 +501,9 @@ class PMProGateway_square extends PMProGateway {
 				'intent'         => $intent,
 				'amount'         => $initial_payment,
 				'currency'       => $pmpro_currency,
+				// Seed the JS billing-required flag so free checkouts (including discount
+				// codes that zero the price) skip tokenization. Mirrors the Stripe gateway.
+				'pmpro_require_billing' => $pmpro_requirebilling,
 			)
 		);
 	}
@@ -540,8 +543,9 @@ class PMProGateway_square extends PMProGateway {
 	 * Use our own payment fields at checkout.
 	 */
 	public function include_payment_information_fields() {
+		global $pmpro_requirebilling;
 		?>
-		<fieldset id="pmpro_payment_information_fields" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fieldset', 'pmpro_payment_information_fields' ) ); ?>">
+		<fieldset id="pmpro_payment_information_fields" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fieldset', 'pmpro_payment_information_fields' ) ); ?>" <?php if ( ! $pmpro_requirebilling ) { ?>style="display: none;"<?php } ?>>
 			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card' ) ); ?>">
 				<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
 					<legend class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_legend' ) ); ?>">


### PR DESCRIPTION
## Problem

Free checkouts fail when Square is the enabled gateway. The form never even submits.

The Square checkout JS binds a click handler to `#pmpro_btn-submit` that calls `event.preventDefault()` and only re-submits the form after a card successfully tokenizes (`pmpro_square_set_payment_token` is the sole path that calls `form.submit()`). On a free checkout there is no card to tokenize, so `tokenize()` throws, control lands in the `catch`, the form is never submitted, and the user is stuck.

This affects every "no payment due" case:
- A natively free level (`initial_payment`/billing/trial all 0).
- A level zeroed by a discount code at page load.
- A level zeroed by a discount code applied *after* page load.

Note that PMPro core never calls `PMProGateway_square::process()` for a free order — `pmpro_isLevelFree()` routes the order to the `'free'` gateway — so this is purely a frontend issue.

## Fix

Mirror the PMPro Stripe integration, which gates on the `pmpro_require_billing` global rather than the price. PMPro seeds that global from the server and the `applydiscountcode` service rewrites it whenever a code is applied, so it stays correct even when a discount zeroes the order after page load.

- **`assets/js/square-processing.js`** — seed `pmpro_require_billing` from a localized value and skip tokenization (letting the form submit natively) when billing isn't required.
- **`classes/class.pmprogateway_square.php`** — localize `pmpro_require_billing`, and hide the payment fields fieldset when billing isn't required (matching the Stripe gateway).

## Testing

- [ ] Free level checkout with Square enabled completes.
- [ ] Discount code that zeroes the price (applied after page load) completes.
- [ ] A normal paid Square checkout still tokenizes and charges as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)